### PR TITLE
Add slot-based storage for dynamic variables

### DIFF
--- a/DynTunes.ConnectorTest/DynTunes.ConnectorTest.csproj
+++ b/DynTunes.ConnectorTest/DynTunes.ConnectorTest.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/DynTunes/Connectors/DummyMusicConnector.cs
+++ b/DynTunes/Connectors/DummyMusicConnector.cs
@@ -32,4 +32,9 @@ public class DummyMusicConnector : IMusicConnector
     {
         return this._state;
     }
+    
+    public void Reconnect()
+    {
+        // Dummy connector doesn't need to reconnect
+    }
 }

--- a/DynTunes/Connectors/IMusicConnector.cs
+++ b/DynTunes/Connectors/IMusicConnector.cs
@@ -3,5 +3,6 @@ namespace DynTunes.Connectors;
 public interface IMusicConnector
 {
     public MediaPlayerState GetState();
+    public void Reconnect();
     // public bool NeedsPolling { get; }
 }

--- a/DynTunes/Connectors/MPRISMusicConnector.cs
+++ b/DynTunes/Connectors/MPRISMusicConnector.cs
@@ -58,7 +58,28 @@ public class MPRISMusicConnector : IMusicConnector
     private async Task ConnectToMPRISAsync(Connection connection)
     {
         string[] services = await connection.ListServicesAsync();
-        string serviceDestination = services.First(s => s.StartsWith("org.mpris.MediaPlayer2."));
+        string[] mprisServices = services.Where(s => s.StartsWith("org.mpris.MediaPlayer2.")).ToArray();
+        
+        if (mprisServices.Length == 0)
+            return;
+        
+        // Prefer Spotify first, then non-browser players, then browsers
+        string? spotifyService = mprisServices.FirstOrDefault(s => s.EndsWith(".spotify"));
+        string? nonBrowserService = mprisServices
+            .Where(s => !s.Contains("chromium", StringComparison.OrdinalIgnoreCase) &&
+                       !s.Contains("brave", StringComparison.OrdinalIgnoreCase) &&
+                       !s.Contains("firefox", StringComparison.OrdinalIgnoreCase) &&
+                       !s.Contains("chrome", StringComparison.OrdinalIgnoreCase) &&
+                       !s.Contains("plasma-browser", StringComparison.OrdinalIgnoreCase))
+            .FirstOrDefault();
+        string? browserService = mprisServices
+            .FirstOrDefault(s => s.Contains("chromium", StringComparison.OrdinalIgnoreCase) ||
+                               s.Contains("brave", StringComparison.OrdinalIgnoreCase) ||
+                               s.Contains("firefox", StringComparison.OrdinalIgnoreCase) ||
+                               s.Contains("chrome", StringComparison.OrdinalIgnoreCase) ||
+                               s.Contains("plasma-browser", StringComparison.OrdinalIgnoreCase));
+        
+        string serviceDestination = spotifyService ?? nonBrowserService ?? browserService ?? mprisServices[0];
 
         MPRISService service = new(connection, serviceDestination);
         Player player = service.CreatePlayer("/org/mpris/MediaPlayer2");
@@ -82,10 +103,42 @@ public class MPRISMusicConnector : IMusicConnector
             switch (key)
             {
                 case "mpris:artUrl":
-                    _state.AlbumArtUrl = value.GetString();
+                    string? artUrl = value.GetString();
+                    if (!string.IsNullOrEmpty(artUrl))
+                    {
+                        // Convert file:// URLs to proper file paths for better Resonite compatibility
+                        if (artUrl.StartsWith("file://"))
+                        {
+                            try
+                            {
+                                Uri uri = new(artUrl);
+                                _state.AlbumArtUrl = Uri.UnescapeDataString(uri.AbsolutePath);
+                            }
+                            catch
+                            {
+                                // If URI parsing fails, try simple string replacement
+                                _state.AlbumArtUrl = artUrl.Replace("file://", "").Replace("%20", " ");
+                            }
+                        }
+                        else
+                        {
+                            // Keep http/https URLs and other formats as-is
+                            _state.AlbumArtUrl = artUrl;
+                        }
+                    }
                     break;
                 case "mpris:length":
-                    _state.LengthSeconds = (float)(value.GetUInt64() / (decimal)TimeSpan.MicrosecondsPerSecond);
+                    // Handle both Int64 and UInt64 types
+                    ulong length;
+                    try
+                    {
+                        length = value.GetUInt64();
+                    }
+                    catch
+                    {
+                        length = (ulong)value.GetInt64();
+                    }
+                    _state.LengthSeconds = (float)(length / (decimal)TimeSpan.MicrosecondsPerSecond);
                     break;
                 case "xesam:album":
                     _state.Album = value.GetString();

--- a/DynTunes/Connectors/MPRISMusicConnector.cs
+++ b/DynTunes/Connectors/MPRISMusicConnector.cs
@@ -1,5 +1,7 @@
 using DynTunes.Integration;
 using Tmds.DBus.Protocol;
+using System.Security.Cryptography;
+using System.Text;
 
 #if !DEBUG
 using Elements.Core;
@@ -12,16 +14,42 @@ public class MPRISMusicConnector : IMusicConnector
 {
     private Player? _player;
     private volatile MediaPlayerState _state = new();
+    private Connection? _connection;
+    private volatile bool _shouldReconnect = false;
+    private DateTime _lastConnectionAttempt = DateTime.MinValue;
+    private const int ReconnectRetryIntervalSeconds = 10;
+    private readonly string _cacheDirectory;
+    private readonly Dictionary<string, string> _urlCache = new(); // URL -> cached file path
+    private readonly HttpClient _httpClient = new();
     
     public MPRISMusicConnector()
     {
+        // Set up cache directory in user's temp folder
+        string tempDir = Path.GetTempPath();
+        _cacheDirectory = Path.Combine(tempDir, "DynTunes", "AlbumArtCache");
+        try
+        {
+            Directory.CreateDirectory(_cacheDirectory);
+        }
+        catch
+        {
+            // If we can't create cache directory, we'll just pass URLs through
+        }
+        
         Task.Factory.StartNew(ConnectAndRunAsync, TaskCreationOptions.LongRunning);
+    }
+
+    public void Reconnect()
+    {
+        _shouldReconnect = true;
+        _player = null;
+        _state.IsConnected = false;
     }
 
     private async Task ConnectAndRunAsync()
     {
-        using Connection connection = new(Address.Session!);
-        await connection.ConnectAsync();
+        _connection = new Connection(Address.Session!);
+        await _connection.ConnectAsync();
 
 #if !DEBUG
         while (!Engine.Current.ShutdownRequested)
@@ -31,19 +59,39 @@ public class MPRISMusicConnector : IMusicConnector
         {
             try
             {
-                if (this._player == null)
-                    await this.ConnectToMPRISAsync(connection);
+                // Check if we need to reconnect or if we're not connected and it's time to retry
+                bool shouldAttemptConnection = _shouldReconnect || 
+                    (_player == null && (DateTime.Now - _lastConnectionAttempt).TotalSeconds >= ReconnectRetryIntervalSeconds);
+                
+                if (shouldAttemptConnection)
+                {
+                    _shouldReconnect = false;
+                    _lastConnectionAttempt = DateTime.Now;
+                    await this.ConnectToMPRISAsync(_connection);
+                }
 
-                await this.UpdateStatusAsync();
+                if (this._player != null)
+                {
+                    await this.UpdateStatusAsync();
+                    _state.IsConnected = true;
+                }
+                else
+                {
+                    _state.IsConnected = false;
+                }
             }
             catch (DBusException e) when(e.ErrorName == "org.freedesktop.DBus.Error.ServiceUnknown")
             {
-                this._state = new MediaPlayerState();
+                this._player = null;
+                this._state.IsConnected = false;
+                // Reset state but keep existing values for display
                 await Task.Delay(5000);
                 continue;
             }
             catch (Exception e)
             {
+                this._player = null;
+                this._state.IsConnected = false;
                 #if !DEBUG
                 UniLog.Warning($"Failed to update MPRIS status: {e}");
                 #else
@@ -61,7 +109,10 @@ public class MPRISMusicConnector : IMusicConnector
         string[] mprisServices = services.Where(s => s.StartsWith("org.mpris.MediaPlayer2.")).ToArray();
         
         if (mprisServices.Length == 0)
+        {
+            _state.IsConnected = false;
             return;
+        }
         
         // Prefer Spotify first, then non-browser players, then browsers
         string? spotifyService = mprisServices.FirstOrDefault(s => s.EndsWith(".spotify"));
@@ -84,7 +135,27 @@ public class MPRISMusicConnector : IMusicConnector
         MPRISService service = new(connection, serviceDestination);
         Player player = service.CreatePlayer("/org/mpris/MediaPlayer2");
 
-        this._player = player;
+        // Check if player is playing before connecting (similar to media-info.sh script behavior)
+        // This ensures we only connect to actively playing media
+        try
+        {
+            string playbackStatus = await player.GetPlaybackStatusAsync();
+            if (playbackStatus == "Playing")
+            {
+                this._player = player;
+                _state.IsConnected = true;
+            }
+            else
+            {
+                _state.IsConnected = false;
+            }
+        }
+        catch
+        {
+            // If we can't get playback status, connect anyway and let UpdateStatusAsync handle it
+            this._player = player;
+            _state.IsConnected = true;
+        }
     }
 
     private async Task UpdateStatusAsync()
@@ -120,9 +191,14 @@ public class MPRISMusicConnector : IMusicConnector
                                 _state.AlbumArtUrl = artUrl.Replace("file://", "").Replace("%20", " ");
                             }
                         }
+                        else if (artUrl.StartsWith("http://") || artUrl.StartsWith("https://"))
+                        {
+                            // Download HTTP/HTTPS images and cache them locally for Resonite compatibility
+                            _state.AlbumArtUrl = await DownloadAndCacheImageAsync(artUrl);
+                        }
                         else
                         {
-                            // Keep http/https URLs and other formats as-is
+                            // Keep other formats as-is
                             _state.AlbumArtUrl = artUrl;
                         }
                     }
@@ -144,12 +220,132 @@ public class MPRISMusicConnector : IMusicConnector
                     _state.Album = value.GetString();
                     break;
                 case "xesam:artist":
-                    _state.Artist = string.Join(", ", value.GetArray<string>());
+                    string[]? artists = value.GetArray<string>();
+                    if (artists != null && artists.Length > 0)
+                    {
+                        _state.Artist = string.Join(", ", artists);
+                    }
+                    break;
+                case "xesam:albumArtist":
+                    // Use albumArtist as fallback if artist wasn't set (common in browser players)
+                    if (string.IsNullOrEmpty(_state.Artist))
+                    {
+                        string[]? albumArtists = value.GetArray<string>();
+                        if (albumArtists != null && albumArtists.Length > 0)
+                        {
+                            _state.Artist = string.Join(", ", albumArtists);
+                        }
+                        else
+                        {
+                            string? albumArtistStr = value.GetString();
+                            if (!string.IsNullOrEmpty(albumArtistStr))
+                            {
+                                _state.Artist = albumArtistStr;
+                            }
+                        }
+                    }
                     break;
                 case "xesam:title":
                     _state.Title = value.GetString();
                     break;
             }
+        }
+    }
+    
+    private async Task<string?> DownloadAndCacheImageAsync(string url)
+    {
+        if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(_cacheDirectory))
+        {
+            return url; // Return original URL if we can't cache
+        }
+
+        try
+        {
+            // Check if we already have this URL cached
+            if (_urlCache.TryGetValue(url, out string? cachedPath) && File.Exists(cachedPath))
+            {
+                return cachedPath;
+            }
+
+            // Generate a cache filename from the URL hash
+            byte[] urlBytes = Encoding.UTF8.GetBytes(url);
+            byte[] hashBytes = SHA256.HashData(urlBytes);
+            string hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+            
+            // Try to determine file extension from URL or content
+            string extension = ".jpg"; // Default
+            try
+            {
+                Uri uri = new(url);
+                string path = uri.AbsolutePath;
+                if (path.Contains('.'))
+                {
+                    string urlExt = Path.GetExtension(path).ToLowerInvariant();
+                    if (urlExt == ".jpg" || urlExt == ".jpeg" || urlExt == ".png" || urlExt == ".webp" || urlExt == ".gif")
+                    {
+                        extension = urlExt;
+                    }
+                }
+            }
+            catch
+            {
+                // Use default extension
+            }
+
+            string cacheFilePath = Path.Combine(_cacheDirectory, $"{hash}{extension}");
+
+            // Download the image
+            using HttpResponseMessage response = await _httpClient.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+            
+            byte[] imageData = await response.Content.ReadAsByteArrayAsync();
+            
+            // Write to cache file
+            await File.WriteAllBytesAsync(cacheFilePath, imageData);
+            
+            // Store in cache dictionary
+            _urlCache[url] = cacheFilePath;
+            
+            // Limit cache size - remove oldest files if cache gets too large (keep last 100)
+            try
+            {
+                string[] cacheFiles = Directory.GetFiles(_cacheDirectory);
+                if (cacheFiles.Length > 100)
+                {
+                    Array.Sort(cacheFiles, (a, b) => File.GetLastWriteTime(a).CompareTo(File.GetLastWriteTime(b)));
+                    for (int i = 0; i < cacheFiles.Length - 100; i++)
+                    {
+                        try
+                        {
+                            File.Delete(cacheFiles[i]);
+                            // Remove from cache dictionary if present
+                            var keyToRemove = _urlCache.FirstOrDefault(kvp => kvp.Value == cacheFiles[i]).Key;
+                            if (keyToRemove != null)
+                            {
+                                _urlCache.Remove(keyToRemove);
+                            }
+                        }
+                        catch
+                        {
+                            // Ignore deletion errors
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore cache cleanup errors
+            }
+
+            return cacheFilePath;
+        }
+        catch
+        {
+            // If download fails, return original URL as fallback
+            #if !DEBUG
+            UniLog.Warning($"Failed to download album art from {url}, using URL directly");
+            #endif
+            return url;
         }
     }
     

--- a/DynTunes/DynTunes.csproj
+++ b/DynTunes/DynTunes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Deterministic>true</Deterministic>

--- a/DynTunes/DynTunes_Config.cs
+++ b/DynTunes/DynTunes_Config.cs
@@ -57,4 +57,10 @@ public partial class DynTunes // Config
     [AutoRegisterConfigKey]
     private static readonly ModConfigurationKey<string> AlbumArtUrlInternal = new("AlbumArtUrl", AlbumArtUrlDescription, () => AlbumArtUrlDefault);
     internal static string AlbumArtUrl => Config?.GetValue(AlbumArtUrlInternal) ?? AlbumArtUrlDefault;
+    
+    private const string SlotNameDescription = "The name of the Slot to create in the UserRoot to store all DynTunes dynamic variables";
+    private const string SlotNameDefault = "🎵 DynTunes";
+    [AutoRegisterConfigKey]
+    private static readonly ModConfigurationKey<string> SlotNameInternal = new("DynTunesSlotName", SlotNameDescription, () => SlotNameDefault);
+    internal static string SlotName => Config?.GetValue(SlotNameInternal) ?? SlotNameDefault;
 }

--- a/DynTunes/DynTunes_Config.cs
+++ b/DynTunes/DynTunes_Config.cs
@@ -58,6 +58,12 @@ public partial class DynTunes // Config
     private static readonly ModConfigurationKey<string> AlbumArtUrlInternal = new("AlbumArtUrl", AlbumArtUrlDescription, () => AlbumArtUrlDefault);
     internal static string AlbumArtUrl => Config?.GetValue(AlbumArtUrlInternal) ?? AlbumArtUrlDefault;
     
+    private const string IsConnectedDescription = "The name to use for the IsConnected boolean";
+    private const string IsConnectedDefault = "IsConnected";
+    [AutoRegisterConfigKey]
+    private static readonly ModConfigurationKey<string> IsConnectedInternal = new("IsConnected", IsConnectedDescription, () => IsConnectedDefault);
+    internal static string IsConnected => Config?.GetValue(IsConnectedInternal) ?? IsConnectedDefault;
+    
     private const string SlotNameDescription = "The name of the Slot to create in the UserRoot to store all DynTunes dynamic variables";
     private const string SlotNameDefault = "🎵 DynTunes";
     [AutoRegisterConfigKey]

--- a/DynTunes/MediaPlayerState.cs
+++ b/DynTunes/MediaPlayerState.cs
@@ -9,4 +9,5 @@ public class MediaPlayerState
     public bool IsPlaying { get; set; }
     public float PositionSeconds { get; set; }
     public float LengthSeconds { get; set; }
+    public bool IsConnected { get; set; }
 }

--- a/DynTunes/Patches/UserRootPatches.cs
+++ b/DynTunes/Patches/UserRootPatches.cs
@@ -70,6 +70,7 @@ public class UserRootPatches
         failed |= !WriteOrAttachDynVar(__instance.Slot, dynTunesSlot, DynTunes.KeyPrefix + DynTunes.Playing, state.IsPlaying);
         failed |= !WriteOrAttachDynVar(__instance.Slot, dynTunesSlot, DynTunes.KeyPrefix + DynTunes.Position, state.PositionSeconds);
         failed |= !WriteOrAttachDynVar(__instance.Slot, dynTunesSlot, DynTunes.KeyPrefix + DynTunes.Length, state.LengthSeconds);
+        failed |= !WriteOrAttachDynVar(__instance.Slot, dynTunesSlot, DynTunes.KeyPrefix + DynTunes.IsConnected, state.IsConnected);
 
         _ = failed; // Todo: warn
     }


### PR DESCRIPTION
- Add config option for slot name (default: 🎵 DynTunes)
- Store all dynamic variables in a dedicated slot instead of directly under UserRoot
- Improve MPRIS player selection (prefer Spotify, then non-browser players)
- Added Int64/UInt64 handling for track length
- Update to .NET 10.0

